### PR TITLE
Ignore "放課後" from numeric character pattern

### DIFF
--- a/lib/amakanize.rb
+++ b/lib/amakanize.rb
@@ -19,7 +19,7 @@ module Amakanize
     |下
     |中
     |前
-    |後
+    |(?<!放課)後
   /x
 
   PATTERN_OF_PREFIX_OF_BOOK_POSITION = /

--- a/spec/amakanize/series_name_spec.rb
+++ b/spec/amakanize/series_name_spec.rb
@@ -89,6 +89,7 @@ RSpec.describe Amakanize::SeriesName do
       "魔法使いの嫁 通常版 4 (BLADE COMICS)" => "魔法使いの嫁",
       "魔法少女育成計画limited（前）" => "魔法少女育成計画limited",
       "ヒナまつり 11<ヒナまつり> (ビームコミックス（ハルタ）)" => "ヒナまつり",
+      "ミキの放課後 (ミリオンコミックス)" => "ミキの放課後",
     }.each do |book_name, expected_series_name|
       context "with #{book_name.inspect}" do
         let(:raw) do


### PR DESCRIPTION
Occur wrong series name and book position detection in https://amakan.net/works/34791/books/76579

```ruby
# expected
Amakanize::SeriesName.new("ミキの放課後 (ミリオンコミックス)").to_s
=> "ミキの放課後"

## actual
Amakanize::SeriesName.new("ミキの放課後 (ミリオンコミックス)").to_s
=> "ミキの放課"
```
