### PR TITLE
Support Ruby version 2.5 or higher

### DIFF
--- a/amakanize.gemspec
+++ b/amakanize.gemspec
@@ -13,9 +13,8 @@ Gem::Specification.new do |spec|
 
   spec.files = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.require_paths = ["lib"]
-  spec.required_ruby_version = ">= 2.2.2"
+  spec.required_ruby_version = ">= 2.5"
 
-  spec.add_dependency "activesupport"
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "3.5.0"

--- a/lib/amakanize/filterable.rb
+++ b/lib/amakanize/filterable.rb
@@ -1,8 +1,8 @@
-require "active_support/concern"
-
 module Amakanize
   module Filterable
-    extend ::ActiveSupport::Concern
+    def self.included(base)
+      base.extend(ClassMethods)
+    end
 
     # @param raw [String]
     def initialize(raw)

--- a/lib/amakanize/filters/normalization_filter.rb
+++ b/lib/amakanize/filters/normalization_filter.rb
@@ -1,4 +1,3 @@
-require "active_support"
 require "amakanize/filters/base_filter"
 
 module Amakanize
@@ -10,7 +9,7 @@ module Amakanize
       def call(context:, output:)
         {
           context: context,
-          output: ::ActiveSupport::Multibyte::Unicode.normalize(output),
+          output: output.unicode_normalize(:nfkc),
         }
       end
     end


### PR DESCRIPTION
lang: EN
ActieveSupport 6.1 and later versions require you to use `String#unicode_normalize(:nfkc)` instead of `ActiveSupport::Multibyte::Unicode#normalize`.
Since `String#unicode_normalize` was added in Ruby 2.5, the supported Ruby version is 2.5 or higher.

As a result, the only code that depends on activesupport is `Akamanize::Filter`, and since the advantage of relying on activesupport is small, activesupport has been removed from the dependency.

lang: JA
ActieveSupport 6.1以降のバージョンでは `ActiveSupport::Multibyte::Unicode#normalize` の変わりに `String#unicode_normalize(:nfkc)` を使用する必要があります。
`String#unicode_normalize` はRuby 2.5で追加されたためサポートするRubyのバージョンを2.5以上としました。

それに伴いactivesupportに依存するコードは `Akamanize::Filter` のみとなり、activesupportに依存するメリットが薄いためactivesupportを依存関係から削除しました。

ref: https://blog.saeloun.com/2020/02/04/rails-6-activesupport-char-unicode-deprecations.html