### PR TITLE
Support Ruby 3

### DIFF
--- a/lib/amakanize/filterable.rb
+++ b/lib/amakanize/filterable.rb
@@ -12,7 +12,7 @@ module Amakanize
     # @note Override
     def to_s
       filters.inject(context: {}, output: raw) do |result, filter|
-        filter.call(result)
+        filter.call(**result)
       end[:output]
     end
 


### PR DESCRIPTION
Fix for Ruby 3.0.

Keyword argument were separated from positional argument.
https://github.com/ruby/ruby/blob/v3_0_0/NEWS.md#language-changes